### PR TITLE
improved audio_decode_frame method

### DIFF
--- a/musicplayer_player_decoding.cpp
+++ b/musicplayer_player_decoding.cpp
@@ -804,11 +804,10 @@ static long audio_decode_frame(PlayerObject* player, PlayerInStream *is, long le
 		/* NOTE: the audio packet can contain several frames */
 		while (pkt_temp->size > 0) {
 			if (!is->frame) {
-				if (!(is->frame = avcodec_alloc_frame()))
+				if (!(is->frame = av_frame_alloc()))
 					return AVERROR(ENOMEM);
-			} else
-				avcodec_get_frame_defaults(is->frame);
-						
+			}
+
 			if (flush_complete)
 				break;
 			int got_frame = 0;


### PR DESCRIPTION
I couldn't install music-player-core with pip on python 2.7.10 and when i tried to compile the package i got the following errors.

`musicplayer_player_decoding.cpp:807:23: error: use of undeclared identifier 'avcodec_alloc_frame'`
`musicplayer_player_decoding.cpp:810:5: error: use of undeclared identifier 'avcodec_get_frame_defaults'`

I then replaced `avcodec_alloc_frame()` with `av_frame_alloc()` and removed `avcodec_get_frame_defaults(is->frame)` because `avcodec_decode_audio4()` apparently will reset the frame itself. After that i could compile the project and also install it with pip. I tested the musicplayer with the example code and it worked.

I'm not at all confident with c++ and therefor not sure if my fix breaks more than it will fix.

I work on a  Mac 10.11.6 with Apple LLVM version 8.0.0.