### PR TITLE
Build wheel from travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ xcshareddata
 # Python distutils
 /MANIFEST
 /dist
+/musicplayer.egg-info
 
 # automatically created (e.g. via qmake)
 Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ thumbnail.bmp
 .idea
 xcshareddata
 
-# Python distutils
+# Python distutils and setuptools
 /MANIFEST
 /dist
 /musicplayer.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,69 +1,13 @@
-language: cpp
+language: python
 
-# do not test on ubuntu 12.04-precise, using 14.04-trusty
-# 16.04-xenial not avail yet
-dist: trusty
+dist: xenial
 
 python:
-  - "2.7"
-  - "2.6"
-  - "3.2"
-  - "3.3"
-  - "3.6" # this is the officially tested and supported one for now
-
-matrix:
-  allow_failures:
-    # not tested at all yet:
-    - python: 2.7
-    - python: 2.6
-    - python: 3.2
-    - python: 3.3
-
-
-compiler:
-# clang 3.0 fails (boost error use of undeclared identifier 'intrusive_ptr_add_ref'), 3.4 ok
-  - clang
-# gcc from travis precise fails (gcc 4.6 doesn't know about "--std=c++11"), ok on tracis trusty
-  - gcc
-
-# for running test and loading libav
-env:
-  LD_LIBRARY_PATH=/usr/local/lib
+  - 3.6
 
 before_install:
-# trusty, https://github.com/travis-ci/travis-ci/issues/5326
-  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-
   - sudo apt-get -qq update
-  - sudo apt-get install -y build-essential yasm libtool python3-dev wget git
-  - sudo apt-get install -y libchromaprint-dev portaudio19-dev
-
-# libboost
-# Travis' Boost is too old (1.46 I think; it misses boost/atomic.hpp).
-# We need at least >=1.55. smart_ptr/intrusive_ref_counter.hpp doesn't exist in older ones.
-# Thus, install a newer one:
-  - wget http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2
-  - tar --bzip2 -xf boost_1_55_0.tar.bz2
-  - cd boost_1_55_0
-#  - ./bootstrap.sh --help
-# We only need atomic (and also only header-only).
-# All the rest takes way too much time to compile.
-  - sudo ./bootstrap.sh --with-libraries="atomic"
-# Way too much output, so just display the last 50 lines.
-  - sudo ./b2 install | tail -n 50
-  - cd ..
-# on trusty
-# - sudo apt-get install -y libboost1.55-dev
-# on xenial (libboost 1.58)
-# - sudo apt-get install -y libboost-dev
-
-# FFMPEG
-# need to use ffmpeg original branch, not libav branch that debian/ubuntu used in 2014 something
-# at least libswresample need to be ported on libav branch
-# from go-libav, then modified
-#  - wget -O ffmpeg.tar.bz2 http://ffmpeg.org/releases/ffmpeg-3.0.tar.bz2
-  - wget -O ffmpeg.tar.bz2 http://ffmpeg.org/releases/ffmpeg-2.8.tar.bz2
-  - mkdir ffmpeg && tar xvf ffmpeg.tar.bz2 -C ffmpeg --strip-components=1 && cd ffmpeg && ./configure --prefix=/usr/local --disable-debug --disable-static --enable-shared --enable-pic --enable-pthreads --disable-indev=jack && make -j4 && sudo make install && cd -
+  - sudo apt-get install -y yasm libtool python3-dev libchromaprint-dev portaudio19-dev libboost-dev libavformat-dev libavresample-dev
 
 #fedora 23
 ## add rpmfusion for ffmpeg
@@ -73,8 +17,19 @@ before_install:
 ## run
 # dnf install -y python ffmpeg portaudio libchromaprint
 
+install:
+  - pip3 install --upgrade pip setuptools wheel
 
 script:
   - python3 setup.py build
-  - sudo python3 setup.py install
+  - pip3 install .
   - python3 -c "import sys; print(sys.path); import musicplayer as mp; p = mp.createPlayer()"
+
+# Deploy package to PyPi
+deploy:
+  provider: pypi
+  user: __token__
+  password:
+    secure: "Your encrypted token"
+  distributions: "sdist bdist_wheel"
+  skip_existing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ python:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y yasm libtool python3-dev libchromaprint-dev portaudio19-dev libboost-dev libavformat-dev libavresample-dev
+  - sudo apt-get install -y yasm libtool python3-dev libchromaprint-dev portaudio19-dev
+  # boost and libav are now up to date in ubuntu repos.
+  - sudo apt-get install libboost-dev libavformat-dev libavresample-dev
 
 #fedora 23
 ## add rpmfusion for ffmpeg
@@ -18,10 +20,12 @@ before_install:
 # dnf install -y python ffmpeg portaudio libchromaprint
 
 install:
+  # necessary to build wheels.
   - pip3 install --upgrade pip setuptools wheel
 
 script:
   - python3 setup.py build
+  # using pip to install so we don't need to be root.
   - pip3 install .
   - python3 -c "import sys; print(sys.path); import musicplayer as mp; p = mp.createPlayer()"
 
@@ -29,7 +33,6 @@ script:
 deploy:
   provider: pypi
   user: __token__
-  password:
-    secure: "Your encrypted token"
+  password : ${PYPI_TOKEN}
   distributions: "sdist bdist_wheel"
   skip_existing: true

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 
 import time
+import setuptools
 from subprocess import check_output
 from distutils.core import setup, Extension
 from glob import glob

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,72 @@
 
+import os
 import time
 import setuptools
+import sys
 from subprocess import check_output
 from distutils.core import setup, Extension
 from glob import glob
+from pprint import pprint
+from subprocess import Popen, check_output, PIPE
+
+
+def debug_print_file(fn):
+    print("%s:" % fn)
+    if not os.path.exists(fn):
+        print("<does not exist>")
+        return
+    if os.path.isdir(fn):
+        print("<dir:>")
+        pprint(os.listdir(fn))
+        return
+    print(open(fn).read())
+
+
+def parse_pkg_info(fn):
+    """
+    :param str fn:
+    :rtype: dict[str,str]
+    """
+    res = {}
+    for ln in open(fn).read().splitlines():
+        if not ln or not ln[:1].strip():
+            continue
+        key, value = ln.split(": ", 1)
+        res[key] = value
+    return res
+
+
+def git_commit_date(commit="HEAD", git_dir="."):
+    out = check_output(["git", "show", "-s", "--format=%ci", commit], cwd=git_dir).decode("utf8")
+    out = out.strip()[:-6].replace(":", "").replace("-", "").replace(" ", ".")
+    return out
+
+
+def git_head_version(git_dir="."):
+    commit_date = git_commit_date(git_dir=git_dir)  # like "20190202.154527"
+    # Make this distutils.version.StrictVersion compatible.
+    return "1.%s" % commit_date
+
+
+if os.path.exists("PKG-INFO"):
+    print("Found existing PKG-INFO.")
+    info = parse_pkg_info("PKG-INFO")
+    version = info["Version"]
+    print("Version via PKG-INFO:", version)
+else:
+    try:
+        version = git_head_version()
+        print("Version via Git:", version)
+    except Exception as exc:
+        print("Exception while getting Git version:", exc)
+        sys.excepthook(*sys.exc_info())
+        version = time.strftime("1.%Y%m%d.%H%M%S", time.gmtime())
+        print("Version via current time:", version)
+
+
+if os.environ.get("DEBUG", "") == "1":
+    debug_print_file(".")
+    debug_print_file("PKG-INFO")
 
 
 # on fedora (23)
@@ -35,7 +98,7 @@ mod = Extension(
 
 setup(
 	name='musicplayer',
-	version=time.strftime("1.%Y%m%d.%H%M%S", time.gmtime()),
+	version=version,
 	description='Music player core Python module',
 	author='Albert Zeyer',
 	author_email='albzey@gmail.com',


### PR DESCRIPTION
This is to automatically deploy the package on pypi from travis. It includes the wheel package (2.5Mo so I guess that the dependencies are not statically linked).

All you need to do is add a `PYPI_TOKEN` variable to your travis environment variables. Then each time you push a commit with a tag travis will upload a new version on PyPi.

I removed the manual installation of boost and ffmpeg as current ubuntu versions now ships a compatible version in their repositories (this makes the builds a lot faster). I also used the `language: python` as this is the only way in travis to make use of the `python: x.x` version selection directive (previously the python and matrix directives had no effect at all). This disabled the `compiler` setting so I removed it also. Maybe I could add back a job matrix with an env variable to test different compilers.

Also, as I added [pbr](https://docs.openstack.org/pbr/3.0.0/) to generate the version number from git, I moved the configuration of `setup.py` into `setup.cfg`.

Fixes #13 (at least for linux_x86_64)